### PR TITLE
Fix incorrect distanceBetween function

### DIFF
--- a/src/org/mdonoughe/JGitDescribeTask.java
+++ b/src/org/mdonoughe/JGitDescribeTask.java
@@ -349,12 +349,12 @@ public class JGitDescribeTask extends Task {
                         }
                     }
                 }
-            	pq.add(commit);
+                pq.add(commit);
                 while (pq.size() > 0) {
                     for (RevCommit pp : pq.remove().getParents()) {
                         if (!seenb.contains(pp)) {
-                        	seenb.add(pp);
-                        	pq.add(pp);
+                            seenb.add(pp);
+                            pq.add(pp);
                         }
                     }
                 }


### PR DESCRIPTION
jgit-describe is calculating the distance as a number a lot lower than git-describe does.

This merges in the fix from erussell/jgit-describe from 2012...
